### PR TITLE
Removing user submitted password

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -10,10 +10,6 @@ rejects: empty|metadata/.*
 
 submission_params:
   - default: ''
-    name: password
-    type: str
-    value: ''
-  - default: ''
     name: start point
     type: str
     value: ''

--- a/xlm_macro_deobfuscator.py
+++ b/xlm_macro_deobfuscator.py
@@ -156,12 +156,10 @@ class XLMMacroDeobfuscator(ServiceBase):
         result = Result()
         request.result = result
         file_path = request.file_path
-        password = request.get_param('password')
         start_point = request.get_param('start point')
 
         try:
             data = process_file(file=file_path,
-                                password=password,
                                 noninteractive=True,
                                 no_indent=True,
                                 output_level=0,
@@ -169,7 +167,6 @@ class XLMMacroDeobfuscator(ServiceBase):
                                 extract_only=True)
 
             data_deobfuscated = process_file(file=file_path,
-                                             password=password,
                                              start_point=start_point,
                                              noninteractive=True,
                                              no_indent=True,
@@ -182,7 +179,5 @@ class XLMMacroDeobfuscator(ServiceBase):
             if str(e).startswith('Failed to decrypt'):
                 section.set_heuristic(6)
             return
-        
+
         add_results(result, data, data_deobfuscated)
-
-


### PR DESCRIPTION
Service is never run on password protected files because of filetypes.
Encrypted excel appears as document/office/passwordprotected and so
is never analyzed by the service. Extract will decrypt password protected
files and allow the decrypted version to be analyzed.
User passwords can be submitted in the Extract password field.