### PR TITLE
Allow config to set service to use XLM via CLI

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -8,6 +8,9 @@ description: >
 accepts: document/office/excel
 rejects: empty|metadata/.*
 
+config:
+  use_CLI: true
+
 submission_params:
   - default: ''
     name: start point

--- a/xlm_macro_deobfuscator.py
+++ b/xlm_macro_deobfuscator.py
@@ -1,9 +1,6 @@
 import collections
-import json
 import re
 
-from subprocess import run
-from tempfile import NamedTemporaryFile
 from typing import Dict, Set, Tuple, List
 
 import XLMMacroDeobfuscator.configs.settings as deob_settings
@@ -182,6 +179,10 @@ class XLMMacroDeobfuscator(ServiceBase):
         data, data_deobfuscated = [], []
 
         def call_CLI(config: dict) -> Dict:
+            import json
+            from tempfile import NamedTemporaryFile
+            from subprocess import run
+
             with NamedTemporaryFile("w+t") as config_file, NamedTemporaryFile() as output:
                 config['export_json'] = output.name
                 json.dump(config, config_file)


### PR DESCRIPTION
Since some of the errors come from the dependency's dependency, I don't exactly want to go down the rabbit hole any more than I have to.

By using the CLI, I can capture stdout and stderr and parse for any exceptions and log them accordingly without having them leak to std streams.

There is now a switch in the manifest to opt to use the CLI or not. Results between the CLI and the module output should match and score identically.